### PR TITLE
refactored slugify so it's more concise

### DIFF
--- a/silly/main.py
+++ b/silly/main.py
@@ -1,5 +1,6 @@
 import datetime as _datetime
 import os
+import re
 import random
 import string
 
@@ -15,20 +16,17 @@ inflectify = inflect.engine()
 def _slugify(string):
     """
     This is not as good as a proper slugification function, but the input space is limited
-
     >>> _slugify("beets")
     'beets'
     >>> _slugify("Toaster Strudel")
     'toaster-strudel'
-
-
     Here's why: It handles very little. It doesn't handle esoteric whitespace or symbols:
-
     >>> _slugify("Hat\\nBasket- of justice and some @#*(! symbols")
     'hat-basket--of-justice-and-some-@#*(!-symbols'
-
     """
-    return string.replace(" ", "-").replace("\n", "-").replace(".", "").replace(",", "").lower()
+    words = re.split(r'[\W]', string)
+    clean_words = [w for w in words if w != '']
+    return '-'.join(clean_words).lower()
 
 
 people = [

--- a/silly/main.py
+++ b/silly/main.py
@@ -16,13 +16,18 @@ inflectify = inflect.engine()
 def _slugify(string):
     """
     This is not as good as a proper slugification function, but the input space is limited
+
     >>> _slugify("beets")
     'beets'
     >>> _slugify("Toaster Strudel")
     'toaster-strudel'
+
+
     Here's why: It handles very little. It doesn't handle esoteric whitespace or symbols:
+
     >>> _slugify("Hat\\nBasket- of justice and some @#*(! symbols")
-    'hat-basket--of-justice-and-some-@#*(!-symbols'
+    'hat-basket-of-justice-and-some-symbols'
+
     """
     words = re.split(r'[\W]', string)
     clean_words = [w for w in words if w != '']
@@ -1149,7 +1154,7 @@ def email(random=random, *args, **kwargs):
     >>> email(random=mock_random)
     'onion@bag-of-heroic-chimps.sexy'
     >>> email(random=mock_random)
-    'agatha-incrediblebritches+spam@amazingbritches.click'
+    'agatha-incrediblebritches-spam@amazingbritches.click'
     >>> email(random=mock_random, name="charles")
     'charles@secret.xyz'
 


### PR DESCRIPTION
Hi! Just a small change - I replaced the original chain of `replace` statements in the `_slugify` function in main.py with a less verbose, and more concise, interpretation using regex. I noticed the replacement of periods and commas as blank space would make `slugify.domain(slugify=True)` not work as it should - in my mind anyways, I'm sure you may have intended to have `violet-dongs.com` to be slugified to `violet-dongscom`.

But for `_slugify("Hat\\nBasket- of justice and some @#*(! symbols")`, instead of `'hat-basket--of-justice-and-some-@#*(!-symbols'` my revision will return `hat-nbasket-of-justice-and-some-symbols`.

I like this tool though, thanks for making silly!
