### PR TITLE
Hyde's hide hid

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ you're probably going to want to look at [faker](https://github.com/joke2k/faker
     silly.verb()
     # jump
     silly.adjective()
-    # hide
+    # musky
     silly.plural()
     # kittens
 


### PR DESCRIPTION
The adjective example, while technically correct, uses a word that only appears in the silly's "verbs" list. I swapped it with an equally "woodsmansy" term from the adjectives list.
